### PR TITLE
Small GUI bugfixes

### DIFF
--- a/calcam/builtin_image_sources/imagefile.py
+++ b/calcam/builtin_image_sources/imagefile.py
@@ -75,12 +75,12 @@ get_image_arguments =  [
                             'arg_name': 'offset_x',
                             'gui_label': 'Detector X Offset',
                             'type': 'int',
-                            'limits':[0,1e4]
+                            'limits':[0,10000]
                         },
                         {
                             'arg_name': 'offset_y',
                             'gui_label': 'Detector Y Offset',
                             'type': 'int',
-                            'limits': [0, 1e4]
+                            'limits': [0, 10000]
                         },
                         ]

--- a/calcam/calibration.py
+++ b/calcam/calibration.py
@@ -2076,7 +2076,7 @@ class Calibration():
             if self.intrinsics_type == 'calibration':
                 hist_str = self.history['intrinsics'][1]
             else:
-                hist_str = self.history['intrinsics']
+                hist_str = self.history['intrinsics'][1]
             msg = msg + 'Intrinsics\n~~~~~~~~~~\nType: {:s}\n{:s}\n\n'.format(self.intrinsics_type.capitalize(),hist_str)
             if self.pixel_size is not None:
                 msg = msg + 'Camera pixel size:           {:.1f} x {:.1f} um\n'.format(1e6*self.pixel_size,1e6*self.pixel_size*self.geometry.pixel_aspectratio)

--- a/calcam/calibration.py
+++ b/calcam/calibration.py
@@ -2073,10 +2073,10 @@ class Calibration():
         # Model info for alignment or virtual selfs
         if self._type in ['alignment','virtual']:
             msg = msg + '------------\nCamera Model\n------------\n\n'
-            if self.intrinsics_type == 'calibration':
+            if isinstance(self.history['intrinsics'], (list, tuple)):
                 hist_str = self.history['intrinsics'][1]
             else:
-                hist_str = self.history['intrinsics'][1]
+                hist_str = self.history['intrinsics']
             msg = msg + 'Intrinsics\n~~~~~~~~~~\nType: {:s}\n{:s}\n\n'.format(self.intrinsics_type.capitalize(),hist_str)
             if self.pixel_size is not None:
                 msg = msg + 'Camera pixel size:           {:.1f} x {:.1f} um\n'.format(1e6*self.pixel_size,1e6*self.pixel_size*self.geometry.pixel_aspectratio)

--- a/calcam/gui/core.py
+++ b/calcam/gui/core.py
@@ -2048,7 +2048,7 @@ class CalibInfoDialog(qt.QDialog):
 
         self.setWindowTitle('Calibration Information.')
 
-        self.resize(parent.size().width()/2,parent.size().height()/2)
+        self.resize(parent.size().width()//2,parent.size().height()//2)
 
         self.setModal(False)
 


### PR DESCRIPTION
I am using Calcam to calibration the coherence imaging spectroscopy cameras on W7-X, and it has worked great! It's a very nice tool.

While using Calcam, I encountered a few bugs with the GUI. These seem to be related to a few PyQt5 functions requiring `int` arguments and receiving `float` data. I suspect this might be due to changes in PyQt5 (I am using version 5.15.7, so pretty new).

There was also a bug where the calibration properties window would not display because the history string was not formatted correctly (this only happened when I loaded the camera intrinsics from a previous manual alignment calibration).

I fixed these small bugs on my system, and wanted to contribute the fixes back.