### PR TITLE
Pull fix to pyproject.toml to release branch

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ calcam = "calcam:start_gui"
 
 [tool.setuptools]
 zip-safe = false
-packages = ["calcam"]
+packages = ["calcam","calcam.gui","calcam.builtin_image_sources"]
 
 [tool.setuptools.package-data]
 calcam = [


### PR DESCRIPTION
This should make sure Calcam can be correctly installed according to the documentation.