### PR TITLE
✨ Add checkbox for fixing principal point in fitting calibration GUI

### DIFF
--- a/calcam/gui/fitting_calib.py
+++ b/calcam/gui/fitting_calib.py
@@ -746,6 +746,10 @@ class FittingCalib(CalcamGUIWindow):
             widgetlist[-1].setChecked(self.fitters[field].fixaspectratio)
             widgetlist[-1].toggled.connect(lambda state,field=field: self.change_fit_params(self.fitters[field].fix_aspect,state))
             perspective_settings_layout.addWidget(widgetlist[-1])
+            widgetlist.append(qt.QCheckBox('Fix Principal Point'))
+            widgetlist[-1].setChecked(self.fitters[field].fixcc)
+            widgetlist[-1].toggled.connect(lambda state,field=field: self.change_fit_params(self.fitters[field].fix_cc,state))
+            perspective_settings_layout.addWidget(widgetlist[-1])
 
 
             # ------- End of perspective settings -----------------


### PR DESCRIPTION
Hello!

I added the checkbox widget to fix the principal point, as it wasn't shown, even though the feature is already implemented in the `Fitter` class.
If you have some reasons to hide it, I will turn down this PR.

Many thanks for considering my request.

