### PR TITLE
Bugfix for camera parameters changing slightly when creating a new viewport

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ build/
 dist/
 .idea/
 calcam/gui/__executable_path__
+error logs/

--- a/calcam/gui/core.py
+++ b/calcam/gui/core.py
@@ -302,12 +302,12 @@ class CalcamGUIWindow(qt.QMainWindow):
             if reply == qt.QMessageBox.No:
                 return
 
-        cam_pos = (self.camX.value(),self.camY.value(),self.camZ.value())
-        target = (self.tarX.value(), self.tarY.value(), self.tarZ.value())
-        fov = self.camFOV.value()
+        cam_pos = self.camera_3d.GetPosition()
+        target = self.camera_3d.GetFocalPoint()
+        fov = self.camera_3d.GetViewAngle()  # This might only work with perspective projections
+        roll = self.interactor3d.cam_roll
         xsection = self.interactor3d.get_xsection()
         projection = self.interactor3d.projection
-        roll = self.cam_roll.value()
 
         try:
             self.cadmodel.add_view(str(self.view_save_name.text()),cam_pos,target,fov,xsection,roll,projection)

--- a/calcam/gui/fitting_calib.py
+++ b/calcam/gui/fitting_calib.py
@@ -109,6 +109,7 @@ class FittingCalib(CalcamGUIWindow):
         self.load_intrinsics_calib_button.clicked.connect(self.modify_intrinsics_calib)
         self.intrinsics_calib_checkbox.toggled.connect(self.toggle_intrinsics_calib)
         self.viewport_load_calib.clicked.connect(self.load_viewport_calib)
+        self.save_view_button.clicked.connect(self.save_view_to_model)
         self.action_save.triggered.connect(self.save_calib)
         self.action_save_as.triggered.connect(lambda: self.save_calib(saveas=True))
         self.action_open.triggered.connect(self.load_calib)

--- a/calcam/gui/qt_designer_files/cad_edit.ui
+++ b/calcam/gui/qt_designer_files/cad_edit.ui
@@ -726,7 +726,7 @@
                  <string> m</string>
                 </property>
                 <property name="decimals">
-                 <number>2</number>
+                 <number>3</number>
                 </property>
                 <property name="minimum">
                  <double>-999.000000000000000</double>
@@ -757,7 +757,7 @@
                  <string> m</string>
                 </property>
                 <property name="decimals">
-                 <number>2</number>
+                 <number>3</number>
                 </property>
                 <property name="minimum">
                  <double>-999.000000000000000</double>
@@ -788,7 +788,7 @@
                  <string> m</string>
                 </property>
                 <property name="decimals">
-                 <number>2</number>
+                 <number>3</number>
                 </property>
                 <property name="minimum">
                  <double>-999.000000000000000</double>
@@ -819,7 +819,7 @@
                  <string> m</string>
                 </property>
                 <property name="decimals">
-                 <number>2</number>
+                 <number>3</number>
                 </property>
                 <property name="minimum">
                  <double>-999.000000000000000</double>
@@ -889,7 +889,7 @@
                  <string> m</string>
                 </property>
                 <property name="decimals">
-                 <number>2</number>
+                 <number>3</number>
                 </property>
                 <property name="minimum">
                  <double>-999.000000000000000</double>
@@ -920,7 +920,7 @@
                  <string> m</string>
                 </property>
                 <property name="decimals">
-                 <number>2</number>
+                 <number>3</number>
                 </property>
                 <property name="minimum">
                  <double>-999.000000000000000</double>
@@ -964,10 +964,10 @@
                  <bool>false</bool>
                 </property>
                 <property name="suffix">
-                 <string> deg</string>
+                 <string>°</string>
                 </property>
                 <property name="decimals">
-                 <number>0</number>
+                 <number>1</number>
                 </property>
                 <property name="maximum">
                  <double>180.000000000000000</double>
@@ -1012,10 +1012,10 @@
                  <bool>false</bool>
                 </property>
                 <property name="suffix">
-                 <string> °</string>
+                 <string>°</string>
                 </property>
                 <property name="decimals">
-                 <number>0</number>
+                 <number>2</number>
                 </property>
                 <property name="minimum">
                  <double>-180.000000000000000</double>

--- a/calcam/gui/qt_designer_files/fitting_calib.ui
+++ b/calcam/gui/qt_designer_files/fitting_calib.ui
@@ -716,7 +716,7 @@
         <item>
          <widget class="QGroupBox" name="groupBox_5">
           <property name="title">
-           <string>Save current view as preset</string>
+           <string>Add current view as preset</string>
           </property>
           <layout class="QHBoxLayout" name="horizontalLayout_3">
            <item>
@@ -736,7 +736,7 @@
            <item>
             <widget class="QPushButton" name="save_view_button">
              <property name="text">
-              <string>Save</string>
+              <string>Add</string>
              </property>
             </widget>
            </item>

--- a/calcam/gui/qt_designer_files/fitting_calib.ui
+++ b/calcam/gui/qt_designer_files/fitting_calib.ui
@@ -256,7 +256,7 @@
                  <bool>false</bool>
                 </property>
                 <property name="decimals">
-                 <number>1</number>
+                 <number>2</number>
                 </property>
                 <property name="maximum">
                  <double>1000000000.000000000000000</double>

--- a/calcam/gui/qt_designer_files/fitting_calib.ui
+++ b/calcam/gui/qt_designer_files/fitting_calib.ui
@@ -998,7 +998,7 @@
                  <bool>false</bool>
                 </property>
                 <property name="suffix">
-                 <string> °</string>
+                 <string>°</string>
                 </property>
                 <property name="decimals">
                  <number>1</number>
@@ -1040,7 +1040,7 @@
                  <bool>false</bool>
                 </property>
                 <property name="suffix">
-                 <string> °</string>
+                 <string>°</string>
                 </property>
                 <property name="decimals">
                  <number>2</number>


### PR DESCRIPTION
I noticed some strange behavior when modifying the viewports for a CAD model definition. I clicked on a predefined viewport from a previous calibration. Then I wanted to make an exact copy of it by typing in a different name and clicking the "Add current view to model definition" button. However, when clicking back it forth between the original and "copied" view, it was clear they had a slight shift. While it wasn't enormous, it was definitely enough to cause noticeable discrepancies between the two viewports.

I ultimately tracked this down to the `save_view_to_model` function using the values entered in the GUI fields to create the new viewport. Because the GUI fields only have 2 decimal places of precision, there is a "rounding error" between the current camera view as reprsented in the GUI and as represented in the internal camera_3d object parameters. I fixed the issue by changing `save_view_to_model` to use the internal camera_3d object parameters when creating the new viewport, instead of using the rounded GUI parameters.

I tested this and it seems to work fine. In the source code there was some special handing for the fov parameter, I think because it is set differently for different projection types. I'm not sure if the change I made works for non-perspective projections, but it also seemed like the CAD model definition editor doesn't use non-perspective projects? So maybe this is fine.

The fact that the view can non-negligibly shift due to rounding errors from 2 decimals of precision (in the camera and target positions) is motivation I think for increasing this to 3 decimals of precision. Also, in the Point Fitting Tool, the 3D Viewport GUI gives 3 decimals of precision. I went ahead and made an update to have the camera view parameters in the CAD model editor have the same decimals of precision as those in the point fitting tool.

I also made a small update to the gitignore file to stop tracking error logs (I assume these shouldn't be tracked?),  changed the decimal precision for pixel size to 2 (since the FLIR polarization cameras have 3.45 um pixel size), and fixed a bug where the "Save current view" button in the Point Fitting tool didn't do anything because it didn't have a callback method.